### PR TITLE
Take another crack at the clean-up problem

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ RHEL := $(shell !(lsb_release -is | grep -qi 'centos\|redhat' ) || \
 	  echo "-DHAVE_RHEL" )
 
 obj-m += zhpe.o
-zhpe-objs += zhpe_core.o zhpe_uuid.o zhpe_zmmu.o zhpe_memreg.o zhpe_pasid.o zhpe_queue.o zhpe_rkey.o zhpe_msg.o zhpe_intr.o
+zhpe-objs += zhpe_core.o zhpe_uuid.o zhpe_zmmu.o zhpe_memreg.o zhpe_pasid.o zhpe_queue.o zhpe_rkey.o zhpe_msg.o zhpe_intr.o zhpe_mmun.o
 
 ccflags-y += -I$ $(src)/include -Wno-date-time -mpreferred-stack-boundary=4
 ccflags-y += $(RHEL)

--- a/include/zhpe_driver.h
+++ b/include/zhpe_driver.h
@@ -42,6 +42,8 @@
 #include <linux/radix-tree.h>
 #include <linux/rbtree.h>
 #include <linux/interrupt.h>
+#include <linux/mmu_notifier.h>
+
 extern uint zhpe_debug_flags;
 extern const char zhpe_driver_name[];
 extern uint no_iommu;
@@ -410,7 +412,11 @@ struct file_data {
     DECLARE_BITMAP(rdm_queues, QUEUES_PER_SLICE*SLICES);
     pid_t               pid;        /* pid that allocated this file_data */
     struct mm_struct    *mm;
+    struct mmu_notifier mmun;
 };
+
+int zhpe_mmun_init(struct file_data *fdata);
+void zhpe_mmun_exit(struct file_data *fdata);
 
 struct io_entry {
     void                (*free)(const char *callf, uint line, void *ptr);

--- a/zhpe_mmun.c
+++ b/zhpe_mmun.c
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2019 Hewlett Packard Enterprise Development LP.
+ * All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <zhpe.h>
+#include <zhpe_driver.h>
+
+static void zhpe_mmun_release(struct mmu_notifier *mn, struct mm_struct *mm)
+{
+    struct file_data    *fdata = container_of(mn, struct file_data, mmun);
+
+    /*
+     * This will be called on the final close of the driver from the process
+     * or during the teardown of the process in the disorderly exit case.
+     *
+     * In either case, our job is to clean up any outstanding Responder
+     * ZMMU entries and memory registrations.
+     */
+    zhpe_umem_free_all(fdata);
+}
+
+static const struct mmu_notifier_ops zhpe_mmun_ops = {
+    .release            = zhpe_mmun_release,
+};
+
+int zhpe_mmun_init(struct file_data *fdata)
+{
+    int                 ret;
+    struct mm_struct    *mm = current->mm;
+
+    BUG_ON(fdata->mm);
+    INIT_HLIST_NODE(&fdata->mmun.hlist);
+    fdata->mmun.ops = &zhpe_mmun_ops;
+
+    ret = mmu_notifier_register(&fdata->mmun, mm);
+    if (ret < 0)
+        return ret;
+
+    fdata->mm = mm;
+
+    return 0;
+}
+
+void zhpe_mmun_exit(struct file_data *fdata)
+{
+    if (fdata->mm)
+        mmu_notifier_unregister(&fdata->mmun, fdata->mm);
+}
+


### PR DESCRIPTION
The previous "placing a hold" solution prevented the
simulator warnings by actually preventing the process's mm
from being cleaned up, so the driver's release function was
never called.

Use a mmu_notifier to get a call when the mm_struct is
being destroyed before the page table is freed.

At some point, we need to use the notifier to clean-up
individual mappings and notify remotes if they are
unmapped.

Signed-off-by: John Byrne <john.l.byrne@hpe.com>